### PR TITLE
Fix processdoc route timeout for Vercel Hobby plan

### DIFF
--- a/app/api/processdoc/route.ts
+++ b/app/api/processdoc/route.ts
@@ -14,7 +14,7 @@ import { revalidatePath } from 'next/cache';
 
 export const dynamic = 'force-dynamic';
 
-export const maxDuration = 800;
+export const maxDuration = 300;
 
 const embeddingModel = voyage.textEmbeddingModel('voyage-3-large', {
   inputType: 'document',


### PR DESCRIPTION
- Reduce maxDuration from 800s to 300s (Hobby plan limit)
- This was causing Vercel deployment failures
- Keeps akratelimits branch in sync with main